### PR TITLE
fix: target older macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ defaults:
 
 env:
   cratename: lonlat_bng
+  MACOSX_DEPLOYMENT_TARGET: "10.9"
 
 name: Test and Cross-compile
 


### PR DESCRIPTION
Not sure what your minimum is, 10.9 is the lowest you should ever set it, 10.10, 10.12, and 10.14 are other common values.