### PR TITLE
Add iteration limit and non-convergence handling to OSGB36→ETRS89 conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lonlat_bng"
 description = "Convert longitude and latitude coordinates to BNG coordinates, and vice versa"
-version = "0.7.14"
+version = "0.7.15"
 authors = ["Stephan Hügel <urschrei@gmail.com>"]
 license = "BlueOak-1.0.0"
 keywords = ["OSGB36", "BNG", "Geo", "ETRS89", "OSTN02", "OSTN15"]

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -25,8 +25,5 @@ fn bench_encode(c: &mut Criterion) {
     });
 }
 
-criterion_group!(
-    benches,
-    bench_encode,
-);
+criterion_group!(benches, bench_encode,);
 criterion_main!(benches);


### PR DESCRIPTION
- Lower convergence threshold from 0.002m to 0.0001m per OSGM15 specification
- Add 10-iteration limit
- Track convergence status and return error if not achieved within limit
- Convert epsilon to const EPSILON and MAX_ITERATIONS for clarity
- Improve comments to reference OSGM15 Transformation and User Guide

This Matches Grid InQuest II implementation behaviour, which raises an error when convergence is not achieved within the iteration limit.